### PR TITLE
Do not clean cache for inivisble products

### DIFF
--- a/app/code/community/Lesti/Fpc/Model/Observer.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer.php
@@ -115,7 +115,11 @@ class Lesti_Fpc_Model_Observer
     {
         $fpc = $this->_getFpc();
         if ($fpc->isActive()) {
+            /* @var Mage_Catalog_Model_Product $product */
             $product = $observer->getEvent()->getProduct();
+            if ($product->getVisibility() == Mage_Catalog_Model_Product_Visibility::VISIBILITY_NOT_VISIBLE) {
+                return;
+            }
             if ($product->getId()) {
                 $fpc->clean(sha1('product_' . $product->getId()));
             }


### PR DESCRIPTION
Hi, I changed the logic for cache-cleaning to skip invisible products. 

I noticed that my import got very slow. We have products with hundreds of variations (Simple Products) which are not visible to the site visitor, and thus are not view- and cache-able. But for every save action Lesti::FPC tells the Cache Backend  to run a cleaning process, which is quite heavy. I think this is unnecessary for invisible products, so added a simple check.
