### PR TITLE
Adding debug mode that displays a custom "Lesti_FPC-Cache" HTTP response...

### DIFF
--- a/app/code/community/Lesti/Fpc/Model/Observer.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer.php
@@ -94,9 +94,18 @@ class Lesti_Fpc_Model_Observer
                 if(Mage::getStoreConfig(self::SHOW_AGE_XML_PATH)) {
                     Mage::app()->getResponse()->setHeader('Age', time()-$time = $object['time']);
                 }
+
+                if(Mage::getConfig()->getNode('global/fpc/debug') == 'true'
+                    || Mage::getConfig()->getNode('global/fpc/debug') == '1'){
+                    Mage::app()->getResponse()->setHeader('X-Lesti_FPC-Cache', 'HIT');
+                }
                 Mage::app()->getResponse()->setBody($body);
                 Mage::app()->getResponse()->sendResponse();
                 exit;
+            }
+            if(Mage::getConfig()->getNode('global/fpc/debug') == 'true'
+                || Mage::getConfig()->getNode('global/fpc/debug') == '1'){
+                Mage::app()->getResponse()->setHeader('X-Lesti_FPC-Cache', 'MISS');
             }
             if(Mage::getStoreConfig(self::SHOW_AGE_XML_PATH)) {
                 Mage::app()->getResponse()->setHeader('Age', 0);

--- a/app/etc/fpc.xml.sample
+++ b/app/etc/fpc.xml.sample
@@ -3,7 +3,7 @@
     <global>
         <fpc>
             <lifetime>86400</lifetime>
-
+	    <debug>false</debug>
             <!-- example for redis -->
             <!-- please read https://github.com/colinmollenhour/Cm_Cache_Backend_Redis for more informations -->
 


### PR DESCRIPTION
Sometimes I find it hard to quickly debug the result of the Lest_FPC cache. I've added a config flag that allows debugging. It simply adds a custom HTTP response header containing either "hit" or "miss".
