### PR TITLE
Add AJAX parameter

### DIFF
--- a/app/code/community/Lesti/Fpc/Helper/Data.php
+++ b/app/code/community/Lesti/Fpc/Helper/Data.php
@@ -81,6 +81,10 @@ class Lesti_Fpc_Helper_Data extends Mage_Core_Helper_Abstract
             if ($currencyCode) {
                 $params['currency'] = $currencyCode;
             }
+            // ajax
+            if(!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest'){
+                $params['ajax'] = 1;
+            }
             $design = Mage::getDesign();
             $params['design'] = $design->getPackageName() . '_' . $design->getTheme('template');
             if (Mage::getStoreConfig(self::XML_PATH_CUSTOMER_GROUPS)) {


### PR DESCRIPTION
Our company uses some methods to load Magento blocks via AJAX and pushState. Could you add this 'ajax' parameter to the params array in order to tell apart AJAX from non-AJAX requests?
