### PR TITLE
Invalidate categories for new products and products status change

### DIFF
--- a/app/code/community/Lesti/Fpc/Model/Observer.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer.php
@@ -250,6 +250,14 @@ class Lesti_Fpc_Model_Observer
             $product = $observer->getEvent()->getProduct();
             if ($product->getId()) {
                 $fpc->clean(sha1('product_' . $product->getId()));
+
+                $origData = $product->getOrigData();
+                if (empty($origData) || (!empty($origData) && $product->getStatus() != $origData['status'])) {
+                    $categories = $product->getCategoryIds();
+                    foreach($categories as $categoryId) {
+                        $fpc->clean(sha1('category_' . $categoryId));
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Hi,

I observed that for new items or disabled items the category does not invalidate. 
Here is a small fix.

Best,
Razvan

PS: Maybe this also solves parts of https://github.com/GordonLesti/Lesti_Fpc/pull/15 issue :)
