### PR TITLE
Added fpc_postdispatch event before sending the cached response

### DIFF
--- a/src/app/code/community/Lesti/Fpc/Model/Observer.php
+++ b/src/app/code/community/Lesti/Fpc/Model/Observer.php
@@ -70,9 +70,10 @@ class Lesti_Fpc_Model_Observer
                     Mage::app()->getResponse()
                         ->setHeader('Age', time() - $time);
                 }
-                Mage::dispatchEvent('fpc_postdispatch');
-                Mage::app()->getResponse()->setBody($body);
-                Mage::app()->getResponse()->sendResponse();
+                $response = Mage::app()->getResponse();
+                $response->setBody($body);
+                Mage::dispatchEvent('fpc_http_response_send_before', array('response'=>$response));
+                $response->sendResponse();
                 exit;
             }
             if (Mage::getStoreConfig(self::SHOW_AGE_XML_PATH)) {


### PR DESCRIPTION
Added a very handy event - necessary for writing cookies and/or other tasks that need to be done after the layout has been generated. Feel free to edit the event name, as long as there is something to listen to between `controller_action_layout_generate_blocks_before` and the sendresponse + exit :)
