### PR TITLE
fixed loading of missing lazy blocks

### DIFF
--- a/app/code/community/Lesti/Fpc/Helper/Block.php
+++ b/app/code/community/Lesti/Fpc/Helper/Block.php
@@ -81,6 +81,9 @@ class Lesti_Fpc_Helper_Block extends Mage_Core_Helper_Abstract
         $design = Mage::getDesign();
         $params['design'] = $design->getPackageName().'_'.
             $design->getTheme('template');
+        
+        $params['blocks'] = implode(',', $this->getLazyBlocks());
+        
         return sha1(serialize($params));
     }
 


### PR DESCRIPTION
Per this conversation https://twitter.com/GordonLesti/status/532450489397706752
the real bug was that the lazy blocks session flag wasn't updated when a new lazy block was being added from the admin. 

For example, if my session started with the default FPC config, and then I edit the fpc settings, adding new lazy blocks, those new blocks would not show up on the frontend, because the "session lock flag" would not change. 
