### PR TITLE
Fix wrong return when empty configuration

### DIFF
--- a/app/code/community/Lesti/Fpc/Helper/Block.php
+++ b/app/code/community/Lesti/Fpc/Helper/Block.php
@@ -28,8 +28,12 @@ class Lesti_Fpc_Helper_Block extends Mage_Core_Helper_Abstract
     public function getDynamicBlocks()
     {
         $blocks = Mage::getStoreConfig(self::DYNAMIC_BLOCKS_XML_PATH);
-        $blocks = array_unique(array_map('trim', explode(',', $blocks)));
-        return $blocks;
+
+        if ($blocks) {
+            return array_unique(array_map('trim', explode(',', $blocks)));
+        }
+
+        return array();
     }
 
     /**
@@ -38,8 +42,12 @@ class Lesti_Fpc_Helper_Block extends Mage_Core_Helper_Abstract
     public function getLazyBlocks()
     {
         $blocks = Mage::getStoreConfig(self::LAZY_BLOCKS_XML_PATH);
-        $blocks = array_unique(array_map('trim', explode(',', $blocks)));
-        return $blocks;
+
+        if ($blocks) {
+            return array_unique(array_map('trim', explode(',', $blocks)));
+        }
+
+        return array();
     }
 
     /**
@@ -81,9 +89,9 @@ class Lesti_Fpc_Helper_Block extends Mage_Core_Helper_Abstract
         $design = Mage::getDesign();
         $params['design'] = $design->getPackageName().'_'.
             $design->getTheme('template');
-        
+
         $params['blocks'] = implode(',', $this->getLazyBlocks());
-        
+
         return sha1(serialize($params));
     }
 

--- a/app/code/community/Lesti/Fpc/Helper/Data.php
+++ b/app/code/community/Lesti/Fpc/Helper/Data.php
@@ -33,7 +33,12 @@ class Lesti_Fpc_Helper_Data extends Mage_Core_Helper_Abstract
     public function getCacheableActions()
     {
         $actions = Mage::getStoreConfig(self::XML_PATH_CACHEABLE_ACTIONS);
-        return array_unique(array_map('trim', explode(',', $actions)));
+
+        if ($actions) {
+            return array_unique(array_map('trim', explode(',', $actions)));
+        }
+
+        return array();
     }
 
     /**
@@ -42,7 +47,12 @@ class Lesti_Fpc_Helper_Data extends Mage_Core_Helper_Abstract
     public function getBypassHandles()
     {
         $handles = Mage::getStoreConfig(self::XML_PATH_BYPASS_HANDLES);
-        return array_unique(array_map('trim', explode(',', $handles)));
+
+        if ($handles) {
+            return array_unique(array_map('trim', explode(',', $handles)));
+        }
+
+        return array();
     }
 
     /**
@@ -51,7 +61,12 @@ class Lesti_Fpc_Helper_Data extends Mage_Core_Helper_Abstract
     public function getRefreshActions()
     {
         $actions = Mage::getStoreConfig(self::XML_PATH_REFRESH_ACTIONS);
-        return array_unique(array_map('trim', explode(',', $actions)));
+
+        if ($actions) {
+            return array_unique(array_map('trim', explode(',', $actions)));
+        }
+
+        return array();
     }
 
     /**
@@ -115,7 +130,7 @@ class Lesti_Fpc_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Matches URI param against expression
      * (string comparison or regular expression)
-     * 
+     *
      * @param string $expression
      * @param string $param
      * @return boolean
@@ -136,7 +151,12 @@ class Lesti_Fpc_Helper_Data extends Mage_Core_Helper_Abstract
     public function _getUriParams()
     {
         $params = Mage::getStoreConfig(self::XML_PATH_URI_PARAMS);
-        return array_map('trim', explode(',', $params));
+
+        if ($params) {
+            return array_map('trim', explode(',', $params));
+        }
+
+        return array();
     }
 
     /**
@@ -145,7 +165,12 @@ class Lesti_Fpc_Helper_Data extends Mage_Core_Helper_Abstract
     protected function _getSessionParams()
     {
         $params = Mage::getStoreConfig(self::XML_PATH_SESSION_PARAMS);
-        return array_map('trim', explode(',', $params));
+
+        if ($params) {
+            return array_map('trim', explode(',', $params));
+        }
+
+        return array();
     }
 
     /**
@@ -154,7 +179,12 @@ class Lesti_Fpc_Helper_Data extends Mage_Core_Helper_Abstract
     protected function _getMissUriParams()
     {
         $params = Mage::getStoreConfig(self::XML_PATH_MISS_URI_PARAMS);
-        return array_unique(array_map('trim', explode(',', $params)));
+
+        if ($params) {
+            return array_unique(array_map('trim', explode(',', $params)));
+        }
+
+        return array();
     }
 
     /**

--- a/app/code/community/Lesti/Fpc/Test/Helper/Block.php
+++ b/app/code/community/Lesti/Fpc/Test/Helper/Block.php
@@ -37,6 +37,17 @@ class Lesti_Fpc_Test_Helper_Block extends Lesti_Fpc_Test_TestCase
             array('messages', 'global_messages', 'global_notices'),
             $this->_blockHelper->getDynamicBlocks()
         );
+
+        $configPath = Lesti_Fpc_Helper_Block::DYNAMIC_BLOCKS_XML_PATH;
+        $oldConfig = Mage::getStoreConfig($configPath);
+        Mage::app()->getStore()->setConfig($configPath, '');
+
+        $this->assertEquals(
+            array(),
+            $this->_blockHelper->getDynamicBlocks()
+        );
+
+        Mage::app()->getStore()->setConfig($configPath, $oldConfig);
     }
 
     /**
@@ -49,6 +60,17 @@ class Lesti_Fpc_Test_Helper_Block extends Lesti_Fpc_Test_TestCase
             array('top.links', 'cart_sidebar', 'catalog.compare.sidebar'),
             $this->_blockHelper->getLazyBlocks()
         );
+
+        $configPath = Lesti_Fpc_Helper_Block::LAZY_BLOCKS_XML_PATH;
+        $oldConfig = Mage::getStoreConfig($configPath);
+        Mage::app()->getStore()->setConfig($configPath, '');
+
+        $this->assertEquals(
+            array(),
+            $this->_blockHelper->getLazyBlocks()
+        );
+
+        Mage::app()->getStore()->setConfig($configPath, $oldConfig);
     }
 
     /**

--- a/app/code/community/Lesti/Fpc/Test/Helper/Data.php
+++ b/app/code/community/Lesti/Fpc/Test/Helper/Data.php
@@ -37,6 +37,17 @@ class Lesti_Fpc_Test_Helper_Data extends Lesti_Fpc_Test_TestCase
             array('cms_index_index', 'cms_page_view', 'catalog_product_view'),
             $this->_helper->getCacheableActions()
         );
+
+        $configPath = Lesti_Fpc_Helper_Data::XML_PATH_CACHEABLE_ACTIONS;
+        $oldConfig = Mage::getStoreConfig($configPath);
+        Mage::app()->getStore()->setConfig($configPath, '');
+
+        $this->assertEquals(
+            array(),
+            $this->_blockHelper->getCacheableActions()
+        );
+
+        Mage::app()->getStore()->setConfig($configPath, $oldConfig);
     }
 
     /**
@@ -49,6 +60,17 @@ class Lesti_Fpc_Test_Helper_Data extends Lesti_Fpc_Test_TestCase
             array('some_handle', 'logged_in', 'CATEGORY_25'),
             $this->_helper->getBypassHandles()
         );
+
+        $configPath = Lesti_Fpc_Helper_Data::XML_PATH_BYPASS_HANDLES;
+        $oldConfig = Mage::getStoreConfig($configPath);
+        Mage::app()->getStore()->setConfig($configPath, '');
+
+        $this->assertEquals(
+            array(),
+            $this->_blockHelper->getBypassHandles()
+        );
+
+        Mage::app()->getStore()->setConfig($configPath, $oldConfig);
     }
 
     /**
@@ -65,11 +87,22 @@ class Lesti_Fpc_Test_Helper_Data extends Lesti_Fpc_Test_TestCase
             ),
             $this->_helper->getRefreshActions()
         );
+
+        $configPath = Lesti_Fpc_Helper_Data::XML_PATH_REFRESH_ACTIONS;
+        $oldConfig = Mage::getStoreConfig($configPath);
+        Mage::app()->getStore()->setConfig($configPath, '');
+
+        $this->assertEquals(
+            array(),
+            $this->_blockHelper->getRefreshActions()
+        );
+
+        Mage::app()->getStore()->setConfig($configPath, $oldConfig);
     }
 
     /**
      * Test that URI params can be matched by RegEx
-     * 
+     *
      * @test
      * @loadFixture regex_uri_params.yaml
      * @dataProvider dataProvider


### PR DESCRIPTION
Fix some "get" methods return when associated configuration entry is empty
see this comment for details:
https://gordonlesti.com/lestifpc/comment-page-14/#comment-21371
