### PR TITLE
Preventing a notice from being thrown when saving a product programmatically when 'status' wasn't added to the select

### DIFF
--- a/app/code/community/Lesti/Fpc/Model/Observer/Save.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer/Save.php
@@ -29,9 +29,9 @@ class Lesti_Fpc_Model_Observer_Save
                 $this->_getFpc()->clean(sha1('product_' . $product->getId()));
 
                 $origData = $product->getOrigData();
-                if (empty($origData) ||
-                    (!empty($origData) &&
-                        $product->getStatus() != $origData['status'])) {
+                if (empty($origData)
+                    || (!empty($origData) && $product->dataHasChangedFor('status'))
+                ) {
                     $categories = $product->getCategoryIds();
                     foreach ($categories as $categoryId) {
                         $this->_getFpc()->clean(


### PR DESCRIPTION
Using `Varien_Object`'s `dataHasChangedFor` instead of comparing origData to  check whether the fpc entry for a product has to be cleared or not. Saving a product won't throw a notice anymore if 'status' wasnt added to the select