### PR TITLE
Added support for Layered Navigation w/out making any configuration changes

### DIFF
--- a/app/code/community/Lesti/Fpc/Helper/Data.php
+++ b/app/code/community/Lesti/Fpc/Helper/Data.php
@@ -154,7 +154,7 @@ class Lesti_Fpc_Helper_Data extends Lesti_Fpc_Helper_Abstract
         // List of attributes that are used in layered navigation
         $layeredNavigationAttributes = array();
 
-        $currentFullActionName = Mage::app()->getFrontController()->getAction()->getFullActionName();
+        $currentFullActionName = $this->getFullActionName();
         if (in_array($currentFullActionName, self::$_pagesWithLayeredNavigation)) {
             /** @var Mage_Catalog_Model_Resource_Product_Attribute_Collection $attributeCollection */
             $attributeCollection = Mage::getResourceModel('catalog/product_attribute_collection');

--- a/app/code/community/Lesti/Fpc/Helper/Data.php
+++ b/app/code/community/Lesti/Fpc/Helper/Data.php
@@ -27,7 +27,12 @@ class Lesti_Fpc_Helper_Data extends Lesti_Fpc_Helper_Abstract
 
     const REGISTRY_KEY_PARAMS = 'fpc_params';
 
-    static protected $_pagesWithLayeredNavigation = array('catalogsearch_result_index', 'catalog_category_layered', 'catalog_category_view');
+    // List of pages that contain layered navigation
+    static protected $_pagesWithLayeredNavigation = array(
+        'catalogsearch_result_index',
+        'catalog_category_layered',
+        'catalog_category_view'
+    );
 
     /**
      * @return array
@@ -154,7 +159,8 @@ class Lesti_Fpc_Helper_Data extends Lesti_Fpc_Helper_Abstract
             /** @var Mage_Catalog_Model_Resource_Product_Attribute_Collection $attributeCollection */
             $attributeCollection = Mage::getResourceModel('catalog/product_attribute_collection');
 
-            // The category and search pages may have different filterable attributes, based on how the attributes are configured
+            // The category and search pages may have different filterable attributes, based on how the attributes
+            // are configured
             switch ($currentFullActionName) {
                 case 'catalogsearch_result_index':
                     $filterableField = 'is_filterable_in_search';

--- a/app/code/community/Lesti/Fpc/etc/config.xml
+++ b/app/code/community/Lesti/Fpc/etc/config.xml
@@ -234,12 +234,14 @@ minicart_head,
 right.poll]]></lazy_blocks>
                 <uri_params><![CDATA[id,
 category,
+cat,
 page_id,
 p,
 limit,
 dir,
 order,
 mode]]></uri_params>
+                <uri_params_layered_navigation>1</uri_params_layered_navigation>
                 <miss_uri_params><![CDATA[no_cache=/^1$/,
 limit=/^([0-9]+)|(all)$/,
 dir=/^[0-9a-z_]+$/,

--- a/app/code/community/Lesti/Fpc/etc/system.xml
+++ b/app/code/community/Lesti/Fpc/etc/system.xml
@@ -27,7 +27,7 @@
                         <cache_actions>
                             <label>Cachable actions</label>
                             <frontend_type>textarea</frontend_type>
-                            <comment>All cachable Actions, seperated with Comma</comment>
+                            <comment>All cachable Actions, separated with Comma</comment>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -36,7 +36,7 @@
                         <dynamic_blocks>
                             <label>Dynamic Blocks</label>
                             <frontend_type>textarea</frontend_type>
-                            <comment>All dynamic Blocks, seperated with Comma</comment>
+                            <comment>All dynamic Blocks, separated with Comma</comment>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -45,7 +45,7 @@
                         <refresh_actions>
                             <label>Refresh Actions</label>
                             <frontend_type>textarea</frontend_type>
-                            <comment>All Action to refresh lazy blocks, seperated with Comma</comment>
+                            <comment>All Action to refresh lazy blocks, separated with Comma</comment>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -54,7 +54,7 @@
                         <bypass_handles>
                             <label>Bypass Handles</label>
                             <frontend_type>textarea</frontend_type>
-                            <comment>All layout handles to bypass FPC, seperated with Comma</comment>
+                            <comment>All layout handles to bypass FPC, separated with Comma</comment>
                             <sort_order>35</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -63,7 +63,7 @@
                         <lazy_blocks>
                             <label>Lazy Blocks</label>
                             <frontend_type>textarea</frontend_type>
-                            <comment>All lazy Blocks, seperated with Comma</comment>
+                            <comment>All lazy Blocks, separated with Comma</comment>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -72,7 +72,7 @@
                         <uri_params>
                             <label>Uri Params</label>
                             <frontend_type>textarea</frontend_type>
-                            <comment>All Uri Params, seperated with Comma. Params enclosed with "/" are treated as regular expression.</comment>
+                            <comment>All Uri Params, separated with Comma. Params enclosed with "/" are treated as regular expression.</comment>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -81,7 +81,7 @@
                         <miss_uri_params>
                             <label>Miss Uri Params</label>
                             <frontend_type>textarea</frontend_type>
-                            <comment>Ignore Requests with this paramters. Regex seperated with comma.</comment>
+                            <comment>Ignore Requests with this parameters. Regex separated with comma.</comment>
                             <sort_order>55</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -90,7 +90,7 @@
                         <session_params>
                             <label>Category Session Params</label>
                             <frontend_type>textarea</frontend_type>
-                            <comment>All Session Params, seperated with comma. Works only on category pages.</comment>
+                            <comment>All Session Params, separated with comma. Works only on category pages.</comment>
                             <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -99,7 +99,7 @@
                         <customer_groups>
                             <label>Customer Group Caching</label>
                             <frontend_type>select</frontend_type>
-                            <comment>Only enable if you have different price or layout for different customergroups.</comment>
+                            <comment>Only enable if you have different price or layout for different customer groups.</comment>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>70</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/community/Lesti/Fpc/etc/system.xml
+++ b/app/code/community/Lesti/Fpc/etc/system.xml
@@ -78,6 +78,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </uri_params>
+                        <uri_params_layered_navigation>
+                            <label>Add Layered Navigation Attributes To Uri Params</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <comment>If set to yes, all attributes that are set to show in the layered navigation will automatically get added to the list of Uri Params.</comment>
+                            <sort_order>52</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </uri_params_layered_navigation>
                         <miss_uri_params>
                             <label>Miss Uri Params</label>
                             <frontend_type>textarea</frontend_type>


### PR DESCRIPTION
I installed this Lesti_Fpc on a site and upon testing it, I found out that it wasn't working with layered navigation. I eventually came across [the post](https://gordonlesti.com/lestifpc-and-layered-navigation/) explaining how to make it work, but by that time I had figured out that I needed to add each attribute to the "Uri Params" textarea in the system config. This solution was clunky, so I decided to add support for the layered navigation attributes to be automatically added to the "Uri Params" list.

I included a system config field so that a user can disable this functionality, if they so desire.

I also fixed a couple of misspellings.