### PR TITLE
Added product reviews support

### DIFF
--- a/app/code/community/Lesti/Fpc/Model/Observer/Save.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer/Save.php
@@ -97,6 +97,28 @@ class Lesti_Fpc_Model_Observer_Save
     /**
      * @param $observer
      */
+    public function reviewDeleteAfter($observer)
+    {
+        if ($this->_getFpc()->isActive()) {
+            $object = $observer->getEvent()->getObject();
+            $this->_getFpc()->clean(sha1('product_' . $object->getEntityPkValue()));
+        }
+    }
+
+    /**
+     * @param $observer
+     */
+    public function reviewSaveAfter($observer)
+    {
+        if ($this->_getFpc()->isActive()) {
+            $object = $observer->getEvent()->getObject();
+            $this->_getFpc()->clean(sha1('product_' . $object->getEntityPkValue()));
+        }
+    }
+
+    /**
+     * @param $observer
+     */
     public function cataloginventoryStockItemSaveAfter($observer)
     {
         $item = $observer->getEvent()->getItem();

--- a/app/code/community/Lesti/Fpc/etc/config.xml
+++ b/app/code/community/Lesti/Fpc/etc/config.xml
@@ -85,6 +85,24 @@
                     </fpc_model_save_after>
                 </observers>
             </model_save_after>
+            <review_delete_after>
+                <observers>
+                    <fpc_review_delete_after>
+                        <class>fpc/observer_save</class>
+                        <type>singleton</type>
+                        <method>reviewDeleteAfter</method>
+                    </fpc_review_delete_after>
+                </observers>
+            </review_delete_after>
+            <review_save_after>
+                <observers>
+                    <fpc_review_save_after>
+                        <class>fpc/observer_save</class>
+                        <type>singleton</type>
+                        <method>reviewSaveAfter</method>
+                    </fpc_review_save_after>
+                </observers>
+            </review_save_after>
             <core_clean_cache>
                 <observers>
                     <fpc_core_clean_cache>


### PR DESCRIPTION
Closes #100 
Product page wasn't being updated after a review approval.
Now it works for:

* Review Save (mass action included)
* Review Delete (mass action included)

Ps: Refreshed by product tag only.