### PR TITLE
add secure to the params/keys

### DIFF
--- a/app/code/community/Lesti/Fpc/Helper/Data.php
+++ b/app/code/community/Lesti/Fpc/Helper/Data.php
@@ -77,6 +77,7 @@ class Lesti_Fpc_Helper_Data extends Lesti_Fpc_Helper_Abstract
             $request = Mage::app()->getRequest();
             $params = array('host' => $request->getServer('HTTP_HOST'),
                 'port' => $request->getServer('SERVER_PORT'),
+                'secure' => Mage::app()->getStore()->isCurrentlySecure(),
                 'full_action_name' => $this->getFullActionName(),
                 'ajax' => $request->isAjax(),
               );


### PR DESCRIPTION
I have HTTP and HTTPS over the same port because I am using SSL offloaded in a load balancer.
In my case I use HTTP from the load balancer to the web server(s).
Magento it self is able to handle that when I configure web/secure/offloader_header

This addition it does work like a charm even if SSL is (also) being handled on port 80.

I would appreciate if that can find a way into the official version.