### PR TITLE
Fixed issue with cached pages and message block

### DIFF
--- a/app/code/community/Lesti/Fpc/etc/config.xml
+++ b/app/code/community/Lesti/Fpc/etc/config.xml
@@ -208,8 +208,8 @@
 cms_page_view,
 catalog_product_view,
 catalog_category_view]]></cache_actions>
-                <dynamic_blocks><![CDATA[messages,
-global_messages,
+                <dynamic_blocks><![CDATA[global_messages,
+messages,
 global_notices,
 global_cookie_notice,
 right.reports.product.viewed]]></dynamic_blocks>


### PR DESCRIPTION
After debugging an issue with session messages, I've found out that the sort order in dynamic blocks is very important and which had a great impact to my problem and solved my issue. 

I guess the problem is that only "global_messages" block is used in the templates. But in the FPC_Observer preparedLayout function all session messages are set to the "messages" block, because its the on the first position in the dynamic_block list. But the "messages" block is used nowhere. So I just switched the positions between "messages" and "global_messages" and  everything works fine for me now.