### PR TITLE
Overwrite Content-Type header

### DIFF
--- a/app/code/community/Lesti/Fpc/Model/Observer.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer.php
@@ -73,7 +73,7 @@ class Lesti_Fpc_Model_Observer
                 if (Mage::getStoreConfig(self::SHOW_AGE_XML_PATH)) {
                     Mage::app()->getResponse()->setHeader('Age', time() - $time);
                 }
-                Mage::app()->getResponse()->setHeader('Content-Type', $object->getContentType());
+                Mage::app()->getResponse()->setHeader('Content-Type', $object->getContentType(), true);
                 $response = Mage::app()->getResponse();
                 $response->setBody($body);
                 Mage::dispatchEvent(


### PR DESCRIPTION
The observer sets the Content-Type header without overwriting it, thus sending it twice (the header will always be set when the response gets created), which can lead to errors with PHP-FPM. Fix this by setting the $replace argument in setHeader to true, overwriting any existing Content-Type headers.