### PR TITLE
Invalidate cache after catalog rule apply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+.idea

--- a/app/code/community/Lesti/Fpc/etc/config.xml
+++ b/app/code/community/Lesti/Fpc/etc/config.xml
@@ -149,6 +149,11 @@
                 </observers>
             </fpc_observer_collect_cache_tags>
         </events>
+        <catalogrule>
+            <related_cache_types>
+                <fpc />
+            </related_cache_types>
+        </catalogrule>
     </global>
     <frontend>
         <routers>


### PR DESCRIPTION
If you look at the core catalogrule module you will find this in ```Mage_CatalogRule_Model_Rule```:

```
/**
     * Invalidate related cache types
     *
     * @return Mage_CatalogRule_Model_Rule
     */
    protected function _invalidateCache()
    {
        $types = $this->_config->getNode(self::XML_NODE_RELATED_CACHE);
        if ($types) {
            $types = $types->asArray();
            $this->_app->getCacheInstance()->invalidateType(array_keys($types));
        }
        return $this;
    }
```

By adding the needed xml entry in Lesti Fpc module, the core code will mark FPC invalidated when catalog rules apply