### PR TITLE
Clean cache for categories on stock change for variants

### DIFF
--- a/app/code/community/Lesti/Fpc/Model/Observer/Save.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer/Save.php
@@ -26,8 +26,24 @@ class Lesti_Fpc_Model_Observer_Save
         if ($this->_getFpc()->isActive()) {
             $product = $observer->getEvent()->getProduct();
             if ($product->getId()) {
-                $this->_getFpc()->clean(sha1('product_' . $product->getId()));
+                $stockItem  = $product->getStockItem();
+                $tags = array(sha1('product_' . $product->getId()));
+                $parentIds = Mage::getModel('catalog/product_type_configurable')->getParentIdsByChild($product->getId());
+                // Clean tag for partner products, if any
+                foreach ($parentIds as $pid) {
+                    $tags[] = sha1('product_' . $pid);
+                }
 
+                if ($parentIds) {
+                    // Clean cache for categories on parent products if stock has changed for simple products
+                    if ($stockItem && $stockItem->dataHasChangedFor('is_in_stock')) {
+                        foreach ($this->_getCategories($parentIds) as $catId) {
+                            $tags[] = sha1('category_' . $catId);
+                        }
+                    }
+                }
+
+                $this->_getFpc()->clean($tags);
                 $origData = $product->getOrigData();
                 if (empty($origData)
                     || (!empty($origData) && $product->dataHasChangedFor('status'))
@@ -156,4 +172,24 @@ class Lesti_Fpc_Model_Observer_Save
             $this->_getFpc()->clean($tags);
         }
     }
+
+    /**
+     * @param array $producIds
+     */
+    protected function _getCategories($productIds)
+    {
+        if (!is_array($productIds)) {
+            $productIds = array($productIds);
+        }
+
+        $catRes = Mage::getResourceModel('catalog/category');
+        $table = $catRes->getTable('catalog/category_product');
+        $conn = $catRes->getReadConnection();
+
+        $query = $conn->select()->from($table,array('category_id'))->where('product_id IN (?)',$productIds);
+        $results = $conn->fetchCol($query);
+
+        return $results;
+    }
+
 }


### PR DESCRIPTION
The problem: If is_in_stock on a simple product is changed. The category where the parent (configurable product) isn't cleaned. 
This will result in too many or too few products showing when filtering on the category pages, when layered navigation is enabled.

An example is:
You sell shoes and have filter on size. The filter show that you have 2 left in size 39. If the simple product is set to not in stock. The categories cache will not be cleaned, and the filter will still show 2 left in size 39, but when you enter the product page the expected size is not available.
The same seems to be the issue if you have a shoe in size 39 that is out of stock, and you get it back into stock. Then this will not show up in the filter until you have cleaned the cache.

This patch will fix both these scenarios by cleaning category cache for all categories where the parent product is located.