### PR TITLE
Avoid reparsing of layout XML when not necessary

### DIFF
--- a/app/code/community/Lesti/Fpc/Model/Observer.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer.php
@@ -212,10 +212,13 @@ class Lesti_Fpc_Model_Observer
         array $dynamicBlocks
     )
     {
-        $xml = simplexml_load_string(
-            $layout->getXmlString(),
-            Lesti_Fpc_Helper_Data::LAYOUT_ELEMENT_CLASS
-        );
+        $xml = $layout->getNode();
+        if (!is_a($xml, Lesti_Fpc_Helper_Data::LAYOUT_ELEMENT_CLASS)) {
+            $xml = simplexml_load_string(
+                $layout->getXmlString(),
+                Lesti_Fpc_Helper_Data::LAYOUT_ELEMENT_CLASS
+            );
+        }
         $cleanXml = simplexml_load_string(
             '<layout/>',
             Lesti_Fpc_Helper_Data::LAYOUT_ELEMENT_CLASS

--- a/app/code/community/Lesti/Fpc/Model/Observer.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer.php
@@ -213,12 +213,6 @@ class Lesti_Fpc_Model_Observer
     )
     {
         $xml = $layout->getNode();
-        if (!is_a($xml, Lesti_Fpc_Helper_Data::LAYOUT_ELEMENT_CLASS)) {
-            $xml = simplexml_load_string(
-                $layout->getXmlString(),
-                Lesti_Fpc_Helper_Data::LAYOUT_ELEMENT_CLASS
-            );
-        }
         $cleanXml = simplexml_load_string(
             '<layout/>',
             Lesti_Fpc_Helper_Data::LAYOUT_ELEMENT_CLASS


### PR DESCRIPTION
Before this commit on each request to a cached page the layout XML would be formatted as a string and then parsed into a new object of type Lesti_Fpc_Helper_Data::LAYOUT_ELEMENT_CLASS.

This is unnecessary as we only read from the layout and the existing layout root node is already a SimpleXMLElement, which has all methods we need.

This saves around 60ms on my local dev environment with PHP 7.0 and Magento 1.9.3.1. Most of the saving comes from not calling getXmlString which internally calls asNiceXml on the layout root node.