### PR TITLE
Flush Magento Cache doesn't do anything

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: fballiano
+buy_me_a_coffee: fballiano
+custom: ["https://paypal.me/fabrizioballiano"]

--- a/README.md
+++ b/README.md
@@ -12,22 +12,22 @@ Simple Magento Fullpagecache. The current documentation can be found
 
 Several quick start options are available:
 ### Install manually
-  * [Download the latest release](https://github.com/GordonLesti/Lesti_Fpc/releases/latest)
+  * [Download the latest release](https://github.com/fballiano/openmage-lesti-fpc/releases/latest)
   * Unzip
   * Copy `app` directory into Magento
 
 ### Install with [modman](https://github.com/colinmollenhour/modman)
 
 ```bash
-modman clone https://github.com/GordonLesti/Lesti_Fpc.git
+modman clone https://github.com/fballiano/openmage-lesti-fpc.git
 ```
 
 ### Install with [Magento Composer Installer](https://github.com/Cotya/magento-composer-installer)
-  * add the requirement `gordonlesti/lesti_fpc`
+  * add the requirement `fballiano/openmage-lesti-fpc`
 ```json
 {
     "require": {
-        "gordonlesti/lesti_fpc": "*"
+        "fballiano/openmage-lesti-fpc": "*"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 [![Latest Release][ico-version]][link-release]
 [![Software License][ico-license]](LICENSE.md)
-[![Build Status][ico-travis]][link-travis]
-[![Coverage Status][ico-coverall]][link-coveralls]
 
-Simple Magento Fullpagecache. The current documentation can be found
+PHP FullPageCache for OpenMage. The current documentation can be found
 [here](https://gordonlesti.com/lesti-fpc-documentationversion-1-4-5/).
 
 ## Install
@@ -32,18 +30,6 @@ modman clone https://github.com/fballiano/openmage-lesti-fpc.git
 }
 ```
 
-## Change log
-
-Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
-
-## Contributing
-
-Please see [CONTRIBUTING](CONTRIBUTING.md) and [CONDUCT](CONDUCT.md) for details.
-
-## Security
-
-If you discover any security related issues, please email info@gordonlesti.com instead of using the issue tracker.
-
 ## Credits
 
 - [Gordon Lesti][link-author]
@@ -53,13 +39,9 @@ If you discover any security related issues, please email info@gordonlesti.com i
 
 The Open Software License v. 3.0 (OSL-3.0). Please see [License File](LICENSE.md) for more information.
 
-[ico-version]: https://img.shields.io/github/release/GordonLesti/Lesti_Fpc.svg?style=flat-square
+[ico-version]: https://img.shields.io/github/release/fballiano/openmage-lesti-fpc.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-OSL--3.0-brightgreen.svg?style=flat-square
-[ico-travis]: https://img.shields.io/travis/GordonLesti/Lesti_Fpc/master.svg?style=flat-square
-[ico-coverall]: https://img.shields.io/coveralls/GordonLesti/Lesti_Fpc/master.svg?style=flat-square
 
-[link-release]: https://github.com/GordonLesti/Lesti_Fpc/releases/latest
-[link-travis]: https://travis-ci.org/GordonLesti/Lesti_Fpc
-[link-coveralls]: https://coveralls.io/r/GordonLesti/Lesti_Fpc
+[link-release]: https://github.com/fballiano/openmage-lesti-fpc/releases/latest
 [link-author]: https://gordonlesti.com/
 [link-contributors]: ../../contributors

--- a/app/code/community/Lesti/Fpc/Helper/Abstract.php
+++ b/app/code/community/Lesti/Fpc/Helper/Abstract.php
@@ -25,7 +25,7 @@ abstract class Lesti_Fpc_Helper_Abstract extends Mage_Core_Helper_Abstract
      */
     public function getCSStoreConfigs($path, $store = null)
     {
-        $configs = trim(Mage::getStoreConfig($path, $store));
+        $configs = trim((string)Mage::getStoreConfig($path, $store));
 
         if ($configs) {
             return array_unique(array_map('trim', explode(',', $configs)));

--- a/app/code/community/Lesti/Fpc/Model/Observer/Clean.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer/Clean.php
@@ -23,20 +23,15 @@ class Lesti_Fpc_Model_Observer_Clean
         $this->_getFpc()->getFrontend()->clean(Zend_Cache::CLEANING_MODE_OLD);
     }
 
-    public function adminhtmlCacheFlushAll()
+    public function flushFpc(Varien_Event_Observer $observer)
     {
-        $this->_getFpc()->clean();
-    }
-
-    public function controllerActionPredispatchAdminhtmlCacheMassRefresh()
-    {
-        $types = Mage::app()->getRequest()->getParam('types');
-        if ($this->_getFpc()->isActive()) {
-            if ((is_array($types) && in_array(self::CACHE_TYPE, $types)) ||
-                $types == self::CACHE_TYPE) {
-                $this->_getFpc()->clean();
-            }
+        // type only exist for event adminhtml_cache_refresh_type
+        $type = $observer->getEvent()->getData('type');
+        if (! empty($type) && $type !== self::CACHE_TYPE) {
+            return;
         }
+
+        $this->_getFpc()->clean();
     }
 
     /**

--- a/app/code/community/Lesti/Fpc/Model/Observer/Clean.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer/Clean.php
@@ -27,17 +27,14 @@ class Lesti_Fpc_Model_Observer_Clean
     {
         // type only exist for event adminhtml_cache_refresh_type
         $type = $observer->getEvent()->getData('type');
-        if (! empty($type) && $type !== self::CACHE_TYPE) {
+        if (! empty($type) && ($type !== self::CACHE_TYPE || ! $this->_getFpc()->isActive())) {
             return;
         }
 
         $this->_getFpc()->clean();
     }
 
-    /**
-     * @return Lesti_Fpc_Model_Fpc
-     */
-    protected function _getFpc()
+    protected function _getFpc(): Lesti_Fpc_Model_Fpc
     {
         return Mage::getSingleton('fpc/fpc');
     }

--- a/app/code/community/Lesti/Fpc/etc/config.xml
+++ b/app/code/community/Lesti/Fpc/etc/config.xml
@@ -231,6 +231,15 @@
                     </fpc_controller_action_predispatch_adminhtml_cache_massRefresh>
                 </observers>
             </controller_action_predispatch_adminhtml_cache_massRefresh>
+            <controller_action_predispatch_adminhtml_cache_flushSystem>
+                <observers>
+                    <fpc_controller_action_predispatch_adminhtml_cache_flushSystem>
+                        <class>fpc/observer_clean</class>
+                        <type>singleton</type>
+                        <method>adminhtmlCacheFlushAll</method>
+                    </fpc_controller_action_predispatch_adminhtml_cache_flushSystem>
+                </observers>
+            </controller_action_predispatch_adminhtml_cache_flushSystem>
         </events>
     </adminhtml>
     <default>

--- a/app/code/community/Lesti/Fpc/etc/config.xml
+++ b/app/code/community/Lesti/Fpc/etc/config.xml
@@ -15,7 +15,7 @@
 <config>
     <modules>
         <Lesti_Fpc>
-            <version>1.5.2</version>
+            <version>1.6.0</version>
         </Lesti_Fpc>
     </modules>
     <global>

--- a/app/code/community/Lesti/Fpc/etc/config.xml
+++ b/app/code/community/Lesti/Fpc/etc/config.xml
@@ -15,7 +15,7 @@
 <config>
     <modules>
         <Lesti_Fpc>
-            <version>1.4.8</version>
+            <version>1.5.2</version>
         </Lesti_Fpc>
     </modules>
     <global>

--- a/app/code/community/Lesti/Fpc/etc/config.xml
+++ b/app/code/community/Lesti/Fpc/etc/config.xml
@@ -121,6 +121,15 @@
                     </fpc_adminhtml_cache_flush_all>
                 </observers>
             </adminhtml_cache_flush_all>
+            <adminhtml_cache_flush_system>
+                <observers>
+                    <fpc_application_cache_flush_system>
+                        <class>fpc/observer_clean</class>
+                        <type>singleton</type>
+                        <method>flushFpc</method>
+                    </fpc_application_cache_flush_system>
+                </observers>
+            </adminhtml_cache_flush_system>
             <adminhtml_cache_refresh_type>
                 <observers>
                     <fpc_adminhtml_cache_refresh_type>
@@ -130,15 +139,6 @@
                     </fpc_adminhtml_cache_refresh_type>
                 </observers>
             </adminhtml_cache_refresh_type>
-            <application_clean_cache>
-                <observers>
-                    <fpc_application_clean_cache>
-                        <class>fpc/observer_clean</class>
-                        <type>singleton</type>
-                        <method>flushFpc</method>
-                    </fpc_application_clean_cache>
-                </observers>
-            </application_clean_cache>
             <cataloginventory_stock_item_save_after>
                 <observers>
                     <fpc_cataloginventory_stock_item_save_after>

--- a/app/code/community/Lesti/Fpc/etc/config.xml
+++ b/app/code/community/Lesti/Fpc/etc/config.xml
@@ -117,10 +117,28 @@
                     <fpc_adminhtml_cache_flush_all>
                         <class>fpc/observer_clean</class>
                         <type>singleton</type>
-                        <method>adminhtmlCacheFlushAll</method>
+                        <method>flushFpc</method>
                     </fpc_adminhtml_cache_flush_all>
                 </observers>
             </adminhtml_cache_flush_all>
+            <adminhtml_cache_refresh_type>
+                <observers>
+                    <fpc_adminhtml_cache_refresh_type>
+                        <class>fpc/observer_clean</class>
+                        <type>singleton</type>
+                        <method>flushFpc</method>
+                    </fpc_adminhtml_cache_refresh_type>
+                </observers>
+            </adminhtml_cache_refresh_type>
+            <application_clean_cache>
+                <observers>
+                    <fpc_application_clean_cache>
+                        <class>fpc/observer_clean</class>
+                        <type>singleton</type>
+                        <method>flushFpc</method>
+                    </fpc_application_clean_cache>
+                </observers>
+            </application_clean_cache>
             <cataloginventory_stock_item_save_after>
                 <observers>
                     <fpc_cataloginventory_stock_item_save_after>
@@ -220,28 +238,6 @@
             </updates>
         </layout>
     </frontend>
-    <adminhtml>
-        <events>
-            <controller_action_predispatch_adminhtml_cache_massRefresh>
-                <observers>
-                    <fpc_controller_action_predispatch_adminhtml_cache_massRefresh>
-                        <class>fpc/observer_clean</class>
-                        <type>singleton</type>
-                        <method>controllerActionPredispatchAdminhtmlCacheMassRefresh</method>
-                    </fpc_controller_action_predispatch_adminhtml_cache_massRefresh>
-                </observers>
-            </controller_action_predispatch_adminhtml_cache_massRefresh>
-            <controller_action_predispatch_adminhtml_cache_flushSystem>
-                <observers>
-                    <fpc_controller_action_predispatch_adminhtml_cache_flushSystem>
-                        <class>fpc/observer_clean</class>
-                        <type>singleton</type>
-                        <method>adminhtmlCacheFlushAll</method>
-                    </fpc_controller_action_predispatch_adminhtml_cache_flushSystem>
-                </observers>
-            </controller_action_predispatch_adminhtml_cache_flushSystem>
-        </events>
-    </adminhtml>
     <default>
         <system>
             <fpc>

--- a/app/etc/fpc.xml.sample
+++ b/app/etc/fpc.xml.sample
@@ -34,6 +34,7 @@
                 <compress_data>1</compress_data>
                 <compress_tags>1</compress_tags>
                 <compress_data>gzip</compress_data>
+                <use_lua>1</use_lua>
             </backend_options-->
 
             <!-- example for apc -->

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "gordonlesti/lesti_fpc",
+    "name": "fballiano/openmage-lesti-fpc",
     "type": "magento-module",
     "description": "Simple Magento Fullpagecache",
     "keywords": ["fpc"],
-    "homepage": "https://github.com/GordonLesti/Lesti_Fpc",
+    "homepage": "https://github.com/fballiano/openmage-lesti-fpc",
     "license": "OSL-3.0",
     "authors": [
         {
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "magento-hackathon/magento-composer-installer": "^3.0"
+        "magento-hackathon/magento-composer-installer": "^3.1 || ^2.1 || ^4.0"
     },
     "require-dev": {
         "ecomdev/ecomdev_phpunit": "^0.3.7",

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,6 @@
             "role": "developer"
         }
     ],
-    "require": {
-        "magento-hackathon/magento-composer-installer": "^3.1 || ^2.1 || ^4.0"
-    },
     "require-dev": {
         "ecomdev/ecomdev_phpunit": "^0.3.7",
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
On my system (openmage 20) when I "flush magento cache" the FPC is not cleaned, thus I catched this new event and it works just fine.